### PR TITLE
Dev databinding newsapi - java

### DIFF
--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/data/NewsRepository.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/data/NewsRepository.java
@@ -1,4 +1,4 @@
-package com.enpassio.databindingwithnewsapi.repository;
+package com.enpassio.databindingwithnewsapi.data;
 
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/model/UIState.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/model/UIState.java
@@ -1,4 +1,4 @@
-package com.enpassio.databindingwithnewsapi.utils;
+package com.enpassio.databindingwithnewsapi.model;
 
 //This enum class is for facilitating the switch between UI state
 public enum UIState{

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/repository/NewsRepository.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/repository/NewsRepository.java
@@ -2,292 +2,57 @@ package com.enpassio.databindingwithnewsapi.repository;
 
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
-import android.content.Context;
-import android.net.Uri;
 import android.os.AsyncTask;
-import android.text.TextUtils;
 import android.util.Log;
 
 import com.enpassio.databindingwithnewsapi.model.Article;
-import com.enpassio.databindingwithnewsapi.utils.Constants;
 import com.enpassio.databindingwithnewsapi.utils.NetworkUtils;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.charset.Charset;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 public class NewsRepository {
 
-    private static NewsRepository sInstance;
+    private static volatile NewsRepository sInstance;
     private final MutableLiveData<List<Article>> articles = new MutableLiveData<>();
     private static final String TAG = "NewsRepository";
-    private final Context mContext;
-    private MutableLiveData<Boolean> isInternetConnected = new MutableLiveData<>();
 
-    private NewsRepository(Context context) {
+    private NewsRepository() {
         Log.d(TAG, "New instance created");
-        mContext = context;
     }
 
-    public static NewsRepository getInstance(Context context) {
+    public static NewsRepository getInstance() {
         if (sInstance == null) {
             synchronized (NewsRepository.class) {
-                sInstance = new NewsRepository(context);
+                if (sInstance == null) {
+                    sInstance = new NewsRepository();
+                }
             }
         }
         return sInstance;
     }
 
-    public void checkConnectionAndStartFetching() {
-        //If data is already there, no need to go over this process again
-        if (articles.getValue() != null && !articles.getValue().isEmpty()) {
-            return;
-        }
-
-        if (NetworkUtils.thereIsConnection(mContext)) {
-            //Pass network state to fragment
-            Log.d(TAG, "there is connection, start fetching");
-            //Start fetching from the News Api in a background thread
-            new NewsAsyncTask().execute();
-            isInternetConnected.setValue(true);
-        } else {
-            Log.d(TAG, "there is no connection");
-            //Pass network state to fragment
-            isInternetConnected.setValue(false);
-        }
+    public void startFetching() {
+        //Start fetching from the News Api in a background thread
+        new NewsAsyncTask().execute();
     }
 
     public LiveData<List<Article>> getArticles() {
         return articles;
     }
 
-    public LiveData<Boolean> getConnectionStatus() {
-        return isInternetConnected;
-    }
-
     private class NewsAsyncTask extends AsyncTask<Void, Void, List<Article>> {
 
         @Override
         protected List<Article> doInBackground(Void... voids) {
-            return fetchArticles();
+            return NetworkUtils.fetchArticles();
         }
 
         @Override
         protected void onPostExecute(List<Article> list) {
-            articles.setValue(list);
+            if(!list.isEmpty()){
+                articles.setValue(list);
+            }
         }
 
-        private List<Article> fetchArticles() {
-            // Create URL object
-            URL url = buildUrl();
-
-            // Perform HTTP request to the URL and receive a JSON response back
-            String jsonResponse = null;
-            try {
-                jsonResponse = makeHttpRequest(url);
-            } catch (IOException e) {
-                Log.e(TAG, "Problem making the HTTP request.", e);
-            }
-
-            // Return the list of {@link Article}s
-            return extractFeatureFromJson(jsonResponse);
-        }
-
-        /**
-         * Returns new URL object from the given string URL.
-         */
-
-        private URL buildUrl() {
-            Uri uri = Uri.parse(Constants.BASE_URL).buildUpon()
-                    .appendPath(Constants.ENDPOINT)
-                    .appendQueryParameter(Constants.CATEGORY, Constants.SAMPLE_CATEGORY)
-                    .appendQueryParameter(Constants.COUNTRY, Constants.SAMPLE_COUNTRY)
-                    .appendQueryParameter(Constants.PAGE_SIZE_PARAM, Constants.SAMPLE_PAGE_SIZE)
-                    .appendQueryParameter(Constants.NEWS_API_KEY, Constants.NEWS_API_VALUE)
-                    .build();
-
-            URL url = null;
-            try {
-                url = new URL(uri.toString());
-                Log.d(TAG, "The build URL: " + uri.toString());
-            } catch (MalformedURLException e) {
-                Log.e(TAG, "Problem building the URL ", e);
-            }
-            return url;
-        }
-
-        /**
-         * Make an HTTP request to the given URL and return a String as the response.
-         */
-        private String makeHttpRequest(URL url) throws IOException {
-            String jsonResponse = "";
-
-            // If the URL is null, then return early.
-            if (url == null) {
-                return jsonResponse;
-            }
-
-            HttpURLConnection urlConnection = null;
-            InputStream inputStream = null;
-            try {
-                urlConnection = (HttpURLConnection) url.openConnection();
-                urlConnection.setReadTimeout(10000 /* milliseconds */);
-                urlConnection.setConnectTimeout(15000 /* milliseconds */);
-                urlConnection.setRequestMethod("GET");
-                urlConnection.connect();
-
-                // If the request was successful (response code 200),
-                // then read the input stream and parse the response.
-                if (urlConnection.getResponseCode() == 200) {
-                    isInternetConnected.postValue(true);
-                    inputStream = urlConnection.getInputStream();
-                    jsonResponse = readFromStream(inputStream);
-                } else {
-                    isInternetConnected.postValue(false);
-                    Log.e(TAG, "Error response code: " + urlConnection.getResponseCode());
-                }
-            } catch (IOException e) {
-                Log.e(TAG, "Problem retrieving the news JSON results.", e);
-            } finally {
-                if (urlConnection != null) {
-                    urlConnection.disconnect();
-                }
-                if (inputStream != null) {
-                    // Closing the input stream could throw an IOException, which is why
-                    // the makeHttpRequest(URL url) method signature specifies than an IOException
-                    // could be thrown.
-                    inputStream.close();
-                }
-            }
-            return jsonResponse;
-        }
-
-        /**
-         * Convert the {@link InputStream} into a String which contains the
-         * whole JSON response from the server.
-         */
-        private String readFromStream(InputStream inputStream) throws IOException {
-            StringBuilder output = new StringBuilder();
-            if (inputStream != null) {
-                InputStreamReader inputStreamReader = new InputStreamReader(inputStream, Charset.forName("UTF-8"));
-                BufferedReader reader = new BufferedReader(inputStreamReader);
-                String line = reader.readLine();
-                while (line != null) {
-                    output.append(line);
-                    line = reader.readLine();
-                }
-            }
-            return output.toString();
-        }
-
-        /**
-         * Return a list of {@link Article} objects that has been built up from
-         * parsing the given JSON response.
-         */
-        private List<Article> extractFeatureFromJson(String articlesJSON) {
-            // If the JSON string is empty or null, then return early.
-            if (TextUtils.isEmpty(articlesJSON)) {
-                return null;
-            }
-
-            // Create an empty ArrayList that we can start adding articles to
-            List<Article> articles = new ArrayList<>();
-
-            // Try to parse the JSON response string. If there's a problem with the way the JSON
-            // is formatted, a JSONException exception object will be thrown.
-            // Catch the exception so the app doesn't crash, and print the error message to the logs.
-            try {
-
-                // Create a JSONObject from the JSON response string
-                JSONObject baseJsonResponse = new JSONObject(articlesJSON);
-
-                // Extract the JSONArray associated with the key called "articles",
-                // which represents a list of articles.
-                JSONArray articlesArray = baseJsonResponse.getJSONArray(Constants.ARTICLES_ARRAY);
-
-                // For each article in the articlesArray, create an {@link Article} object
-                for (int i = 0; i < articlesArray.length(); i++) {
-
-                    // Get a single article at position i within the list of articles
-                    JSONObject currentArticle = articlesArray.getJSONObject(i);
-
-                    //Retrieve the field that you need from this json object:
-
-                    // Extract the value for the key called "author"
-                    String author = currentArticle.getString(Constants.AUTHOR);
-
-                    // Extract the value for the key called "title"
-                    String title = currentArticle.getString(Constants.TITLE);
-
-                    // Extract the value for the key called "description"
-                    String description = currentArticle.getString(Constants.DESCRIPTION);
-
-                    // Extract the value for the article url
-                    String articleUrl = currentArticle.getString(Constants.ARTICLE_URL);
-
-                    // Extract the value for the image url
-                    String imageUrl = currentArticle.getString(Constants.IMAGE_URL);
-
-                    //Extract the value for the key "publishedAt"
-                    String publishingTime = formatDateTime(currentArticle.getString(Constants.PUBLISHING_TIME));
-
-                    //Extract the value for the key "content"
-                    String articleBody = currentArticle.getString(Constants.ARTICLE_BODY);
-
-                    //Source name is inside a source json object, so we first need to get this object
-                    JSONObject sourceJSON = currentArticle.getJSONObject(Constants.SOURCE);
-
-                    //Then we get the source name from this sourceJSON
-                    String sourceName = sourceJSON.getString(Constants.SOURCE_NAME);
-
-                    // Create a new {@link Article} object with
-                    Article article = new Article(sourceName, author, title, description, articleUrl, imageUrl, publishingTime, articleBody);
-
-                    // Add the new {@link Article} to the list of articles.
-                    articles.add(article);
-                }
-
-            } catch (JSONException e) {
-                // If an error is thrown when executing any of the above statements in the "try" block,
-                // catch the exception here, so the app doesn't crash. Print a log message
-                // with the message from the exception.
-                Log.e(TAG, "Problem parsing the NewsApi JSON results", e);
-            }
-
-            // Return the list of articles
-            return articles;
-        }
-
-        private String formatDateTime(String dateTime) {
-            TimeZone timeZone = TimeZone.getTimeZone("UTC");
-            SimpleDateFormat sourceFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-            sourceFormat.setTimeZone(timeZone);
-            Date parsedTime = null;
-            try {
-                parsedTime = sourceFormat.parse(dateTime);
-            } catch (ParseException e) {
-                e.printStackTrace();
-            }
-
-            TimeZone tz = TimeZone.getDefault();
-            SimpleDateFormat destFormat = new SimpleDateFormat("LLL dd, yyyy'T'HH:mm");
-            destFormat.setTimeZone(tz);
-            return destFormat.format(parsedTime);
-        }
     }
 }

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleDetailsFragment.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleDetailsFragment.java
@@ -1,13 +1,17 @@
 package com.enpassio.databindingwithnewsapi.ui;
 
 import android.arch.lifecycle.ViewModelProviders;
+import android.content.Intent;
 import android.databinding.DataBindingUtil;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -17,9 +21,12 @@ import com.enpassio.databindingwithnewsapi.R;
 import com.enpassio.databindingwithnewsapi.databinding.FragmentDetailsBinding;
 import com.enpassio.databindingwithnewsapi.viewmodel.MainViewModel;
 
+import static android.support.constraint.Constraints.TAG;
+
 public class ArticleDetailsFragment extends Fragment {
 
     private FragmentDetailsBinding binding;
+    private MainViewModel viewModel;
 
     public ArticleDetailsFragment() {
     }
@@ -34,6 +41,8 @@ public class ArticleDetailsFragment extends Fragment {
         ((AppCompatActivity) requireActivity()).setSupportActionBar(binding.toolbar);
         setHasOptionsMenu(true);
 
+        binding.detailsReadMore.setOnClickListener(v -> openWebSite());
+
         return binding.getRoot();
     }
 
@@ -41,9 +50,8 @@ public class ArticleDetailsFragment extends Fragment {
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         //Get an instance of view model and pass it to the binding implementation
-        MainViewModel viewModel = ViewModelProviders.of(requireActivity()).get(MainViewModel.class);
+        viewModel = ViewModelProviders.of(requireActivity()).get(MainViewModel.class);
         binding.setViewModel(viewModel);
-
     }
 
     @Override
@@ -56,5 +64,25 @@ public class ArticleDetailsFragment extends Fragment {
             }
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    public void openWebSite() {
+        String articleUrl = viewModel.getChosenArticle().getArticleUrl();
+        Uri webUri = null;
+        if (!TextUtils.isEmpty(articleUrl)) {
+            //Parse string to uri
+            try {
+                webUri = Uri.parse(articleUrl);
+            } catch (Exception e) {
+                Log.e(TAG, e.toString());
+            }
+            //Send an implicit intent to open the article in the browser
+            Intent webIntent = new Intent(Intent.ACTION_VIEW);
+            webIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            webIntent.setData(webUri);
+            if (webIntent.resolveActivity(requireActivity().getPackageManager()) != null) {
+                requireActivity().startActivity(webIntent);
+            }
+        }
     }
 }

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleDetailsFragment.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleDetailsFragment.java
@@ -19,7 +19,6 @@ import android.view.ViewGroup;
 
 import com.enpassio.databindingwithnewsapi.R;
 import com.enpassio.databindingwithnewsapi.databinding.FragmentDetailsBinding;
-import com.enpassio.databindingwithnewsapi.viewmodel.MainViewModel;
 
 import static android.support.constraint.Constraints.TAG;
 

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleListFragment.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleListFragment.java
@@ -56,13 +56,14 @@ public class ArticleListFragment extends Fragment implements NewsAdapter.Article
         //Get the view model instance and pass it to the binding implementation
         mViewModel = ViewModelProviders.of(requireActivity()).get(MainViewModel.class);
         binding.included.setViewModel(mViewModel);
+        binding.setLifecycleOwner(this.getViewLifecycleOwner());
 
         //Claim the list from the view model and observe the results
         mViewModel.getArticleList().observe(this, articles -> {
             if (articles != null && !articles.isEmpty()) {
                 /*When articles are received, hide the loading indicator
                 and pass the articles to the adapter*/
-                mViewModel.uiState.set(UIState.SUCCESS);
+                mViewModel.uiState.setValue(UIState.SUCCESS);
                 mAdapter.setArticleList(articles);
                 Log.d(TAG, "articles are received. list size: " + articles.size());
             }

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleListFragment.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleListFragment.java
@@ -58,21 +58,6 @@ public class ArticleListFragment extends Fragment implements NewsAdapter.Article
         mViewModel = ViewModelProviders.of(requireActivity()).get(MainViewModel.class);
         binding.included.setViewModel(mViewModel);
 
-        //Verify the connection and start loading from the api
-        mViewModel.checkConnectionAndStartLoading();
-
-        mViewModel.getConnectionStatus().observe(this, isConnected -> {
-            /*If network is connected, set as "loading" until data arrives. If there
-            is no connection, remove loading indicator and show no network image instead*/
-            //If there is no network, show a snack bar to warn the user.
-            if (!isConnected) {
-                mViewModel.uiState.set(UIState.NETWORK_ERROR);
-                showSnack();
-            } else {
-                mViewModel.uiState.set(UIState.LOADING);
-            }
-        });
-
         //Claim the list from the view model and observe the results
         mViewModel.getArticleList().observe(this, articles -> {
             if (articles != null && !articles.isEmpty()) {
@@ -81,6 +66,12 @@ public class ArticleListFragment extends Fragment implements NewsAdapter.Article
                 mViewModel.uiState.set(UIState.SUCCESS);
                 mAdapter.setArticleList(articles);
                 Log.d(TAG, "articles are received. list size: " + articles.size());
+            }
+        });
+
+        mViewModel.shouldShowSnack().observe(this, shouldShow -> {
+            if (shouldShow) {
+                showSnack();
             }
         });
     }

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleListFragment.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleListFragment.java
@@ -55,7 +55,7 @@ public class ArticleListFragment extends Fragment implements NewsAdapter.Article
 
         //Get the view model instance and pass it to the binding implementation
         mViewModel = ViewModelProviders.of(requireActivity()).get(MainViewModel.class);
-        binding.included.setViewModel(mViewModel);
+        binding.included.setUiState(mViewModel.getUiState());
         binding.setLifecycleOwner(this.getViewLifecycleOwner());
 
         //Claim the list from the view model and observe the results
@@ -63,7 +63,7 @@ public class ArticleListFragment extends Fragment implements NewsAdapter.Article
             if (articles != null && !articles.isEmpty()) {
                 /*When articles are received, hide the loading indicator
                 and pass the articles to the adapter*/
-                mViewModel.uiState.setValue(UIState.SUCCESS);
+                mViewModel.setUiState(UIState.SUCCESS);
                 mAdapter.setArticleList(articles);
                 Log.d(TAG, "articles are received. list size: " + articles.size());
             }

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleListFragment.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/ArticleListFragment.java
@@ -19,8 +19,7 @@ import android.view.ViewGroup;
 import com.enpassio.databindingwithnewsapi.R;
 import com.enpassio.databindingwithnewsapi.databinding.NewsListBinding;
 import com.enpassio.databindingwithnewsapi.model.Article;
-import com.enpassio.databindingwithnewsapi.utils.UIState;
-import com.enpassio.databindingwithnewsapi.viewmodel.MainViewModel;
+import com.enpassio.databindingwithnewsapi.model.UIState;
 
 public class ArticleListFragment extends Fragment implements NewsAdapter.ArticleClickListener{
 

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/MainViewModel.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/MainViewModel.java
@@ -1,4 +1,4 @@
-package com.enpassio.databindingwithnewsapi.viewmodel;
+package com.enpassio.databindingwithnewsapi.ui;
 
 import android.app.Application;
 import android.arch.lifecycle.AndroidViewModel;
@@ -7,10 +7,10 @@ import android.arch.lifecycle.MutableLiveData;
 import android.databinding.ObservableField;
 import android.support.annotation.NonNull;
 
+import com.enpassio.databindingwithnewsapi.data.NewsRepository;
 import com.enpassio.databindingwithnewsapi.model.Article;
-import com.enpassio.databindingwithnewsapi.repository.NewsRepository;
+import com.enpassio.databindingwithnewsapi.model.UIState;
 import com.enpassio.databindingwithnewsapi.utils.NetworkUtils;
-import com.enpassio.databindingwithnewsapi.utils.UIState;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ public class MainViewModel extends AndroidViewModel {
         showSnack.setValue(false);
     }
 
-    public LiveData<List<Article>> getArticleList() {
+    LiveData<List<Article>> getArticleList() {
         if (mArticleList == null) {
             mArticleList = mRepo.getArticles();
             checkConnectionAndStartLoading();
@@ -41,17 +41,17 @@ public class MainViewModel extends AndroidViewModel {
         return mChosenArticle;
     }
 
-    public void setChosenArticle(Article chosenArticle) {
+    void setChosenArticle(Article chosenArticle) {
         mChosenArticle = chosenArticle;
     }
 
-    public LiveData<Boolean> shouldShowSnack() {
+    LiveData<Boolean> shouldShowSnack() {
         return showSnack;
     }
 
     /*If there is internet connection, start fetching data from the internet,
    otherwise show a snack for warning user*/
-    public void checkConnectionAndStartLoading() {
+    void checkConnectionAndStartLoading() {
         if (NetworkUtils.thereIsConnection(getApplication())) {
             /*If there is connection, start fetching and change uiState
             to LOADING. This will show a loading indicator*/

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/MainViewModel.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/MainViewModel.java
@@ -19,7 +19,7 @@ public class MainViewModel extends AndroidViewModel {
     private Article mChosenArticle;
     private final NewsRepository mRepo;
     private MutableLiveData<Boolean> showSnack = new MutableLiveData<>();
-    public final MutableLiveData<UIState> uiState = new MutableLiveData<>();
+    private final MutableLiveData<UIState> uiState = new MutableLiveData<>();
 
     public MainViewModel(@NonNull Application application) {
         super(application);
@@ -43,6 +43,14 @@ public class MainViewModel extends AndroidViewModel {
 
     void setChosenArticle(Article chosenArticle) {
         mChosenArticle = chosenArticle;
+    }
+
+    public LiveData<UIState> getUiState() {
+        return uiState;
+    }
+
+    public void setUiState(UIState newState){
+        uiState.setValue(newState);
     }
 
     LiveData<Boolean> shouldShowSnack() {

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/MainViewModel.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/ui/MainViewModel.java
@@ -4,7 +4,6 @@ import android.app.Application;
 import android.arch.lifecycle.AndroidViewModel;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
-import android.databinding.ObservableField;
 import android.support.annotation.NonNull;
 
 import com.enpassio.databindingwithnewsapi.data.NewsRepository;
@@ -20,12 +19,13 @@ public class MainViewModel extends AndroidViewModel {
     private Article mChosenArticle;
     private final NewsRepository mRepo;
     private MutableLiveData<Boolean> showSnack = new MutableLiveData<>();
-    public final ObservableField<UIState> uiState = new ObservableField<>(UIState.LOADING);
+    public final MutableLiveData<UIState> uiState = new MutableLiveData<>();
 
     public MainViewModel(@NonNull Application application) {
         super(application);
         //Passing the application context to the repository (not activity context!)
         mRepo = NewsRepository.getInstance();
+        uiState.setValue(UIState.LOADING);
         showSnack.setValue(false);
     }
 
@@ -55,7 +55,7 @@ public class MainViewModel extends AndroidViewModel {
         if (NetworkUtils.thereIsConnection(getApplication())) {
             /*If there is connection, start fetching and change uiState
             to LOADING. This will show a loading indicator*/
-            uiState.set(UIState.LOADING);
+            uiState.setValue(UIState.LOADING);
             mRepo.startFetching();
             showSnack.setValue(false);
         } else {
@@ -64,7 +64,7 @@ public class MainViewModel extends AndroidViewModel {
             /*Unless there is some previously fetched data to show,
             set uiState to NETWORK_ERROR This will show an error message*/
             if(mArticleList.getValue() == null || mArticleList.getValue().isEmpty()){
-                uiState.set(UIState.NETWORK_ERROR);
+                uiState.setValue(UIState.NETWORK_ERROR);
             }
         }
     }

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/viewmodel/MainViewModel.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/viewmodel/MainViewModel.java
@@ -3,6 +3,7 @@ package com.enpassio.databindingwithnewsapi.viewmodel;
 import android.app.Application;
 import android.arch.lifecycle.AndroidViewModel;
 import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
 import android.content.Intent;
 import android.databinding.ObservableField;
 import android.net.Uri;
@@ -13,6 +14,7 @@ import android.view.View;
 
 import com.enpassio.databindingwithnewsapi.model.Article;
 import com.enpassio.databindingwithnewsapi.repository.NewsRepository;
+import com.enpassio.databindingwithnewsapi.utils.NetworkUtils;
 import com.enpassio.databindingwithnewsapi.utils.UIState;
 
 import java.util.List;
@@ -24,17 +26,20 @@ public class MainViewModel extends AndroidViewModel {
     private LiveData<List<Article>> mArticleList;
     private Article mChosenArticle;
     private final NewsRepository mRepo;
+    private MutableLiveData<Boolean> showSnack = new MutableLiveData<>();
     public final ObservableField<UIState> uiState = new ObservableField<>(UIState.LOADING);
 
     public MainViewModel(@NonNull Application application) {
         super(application);
         //Passing the application context to the repository (not activity context!)
-        mRepo = NewsRepository.getInstance(this.getApplication());
+        mRepo = NewsRepository.getInstance();
+        showSnack.setValue(false);
     }
 
     public LiveData<List<Article>> getArticleList() {
         if (mArticleList == null) {
             mArticleList = mRepo.getArticles();
+            checkConnectionAndStartLoading();
         }
         return mArticleList;
     }
@@ -47,14 +52,29 @@ public class MainViewModel extends AndroidViewModel {
         mChosenArticle = chosenArticle;
     }
 
-    public LiveData<Boolean> getConnectionStatus(){
-        return mRepo.getConnectionStatus();
+    public LiveData<Boolean> shouldShowSnack() {
+        return showSnack;
     }
 
+    /*If there is internet connection, start fetching data from the internet,
+   otherwise show a snack for warning user*/
     public void checkConnectionAndStartLoading() {
-        mRepo.checkConnectionAndStartFetching();
+        if (NetworkUtils.thereIsConnection(getApplication())) {
+            /*If there is connection, start fetching and change uiState
+            to LOADING. This will show a loading indicator*/
+            uiState.set(UIState.LOADING);
+            mRepo.startFetching();
+            showSnack.setValue(false);
+        } else {
+            //If there is no connection, show a snack message to warn user
+            showSnack.setValue(true);
+            /*Unless there is some previously fetched data to show,
+            set uiState to NETWORK_ERROR This will show an error message*/
+            if(mArticleList.getValue() == null || mArticleList.getValue().isEmpty()){
+                uiState.set(UIState.NETWORK_ERROR);
+            }
+        }
     }
-
     public void openWebSite(View view) {
         if (mChosenArticle == null) {
             return;

--- a/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/viewmodel/MainViewModel.java
+++ b/DatabindingWithNewsApi/app/src/main/java/com/enpassio/databindingwithnewsapi/viewmodel/MainViewModel.java
@@ -4,13 +4,8 @@ import android.app.Application;
 import android.arch.lifecycle.AndroidViewModel;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
-import android.content.Intent;
 import android.databinding.ObservableField;
-import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
-import android.util.Log;
-import android.view.View;
 
 import com.enpassio.databindingwithnewsapi.model.Article;
 import com.enpassio.databindingwithnewsapi.repository.NewsRepository;
@@ -18,8 +13,6 @@ import com.enpassio.databindingwithnewsapi.utils.NetworkUtils;
 import com.enpassio.databindingwithnewsapi.utils.UIState;
 
 import java.util.List;
-
-import static android.support.constraint.Constraints.TAG;
 
 public class MainViewModel extends AndroidViewModel {
 
@@ -72,28 +65,6 @@ public class MainViewModel extends AndroidViewModel {
             set uiState to NETWORK_ERROR This will show an error message*/
             if(mArticleList.getValue() == null || mArticleList.getValue().isEmpty()){
                 uiState.set(UIState.NETWORK_ERROR);
-            }
-        }
-    }
-    public void openWebSite(View view) {
-        if (mChosenArticle == null) {
-            return;
-        }
-        String articleUrl = mChosenArticle.getArticleUrl();
-        Uri webUri = null;
-        if (!TextUtils.isEmpty(articleUrl)) {
-            //Parse string to uri
-            try {
-                webUri = Uri.parse(articleUrl);
-            } catch (Exception e) {
-                Log.e(TAG, e.toString());
-            }
-            //Send an implicit intent to open the article in the browser
-            Intent webIntent = new Intent(Intent.ACTION_VIEW);
-            webIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            webIntent.setData(webUri);
-            if (webIntent.resolveActivity(view.getContext().getPackageManager()) != null) {
-                view.getContext().startActivity(webIntent);
             }
         }
     }

--- a/DatabindingWithNewsApi/app/src/main/res/layout/fragment_details.xml
+++ b/DatabindingWithNewsApi/app/src/main/res/layout/fragment_details.xml
@@ -183,7 +183,6 @@
                     style="@style/Widget.Button.TextButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:onClick="@{viewModel::openWebSite}"
                     android:text="@string/read_more"
                     app:backgroundTint="@color/colorPrimary"
                     app:layout_constraintBottom_toBottomOf="parent"

--- a/DatabindingWithNewsApi/app/src/main/res/layout/fragment_details.xml
+++ b/DatabindingWithNewsApi/app/src/main/res/layout/fragment_details.xml
@@ -8,7 +8,7 @@
         we will call its fields to populate our layout -->
         <variable
             name="viewModel"
-            type="com.enpassio.databindingwithnewsapi.viewmodel.MainViewModel" />
+            type="com.enpassio.databindingwithnewsapi.ui.MainViewModel" />
 
         <import type="com.enpassio.databindingwithnewsapi.utils.BindingUtils" />
 

--- a/DatabindingWithNewsApi/app/src/main/res/layout/fragment_list.xml
+++ b/DatabindingWithNewsApi/app/src/main/res/layout/fragment_list.xml
@@ -3,11 +3,11 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-        <variable
-            name="viewModel"
-            type="com.enpassio.databindingwithnewsapi.ui.MainViewModel" />
-
         <import type="com.enpassio.databindingwithnewsapi.model.UIState" />
+        <import type="android.arch.lifecycle.LiveData"/>
+        <variable
+            name="uiState"
+            type="LiveData&lt;UIState>" />
     </data>
 
     <FrameLayout
@@ -19,7 +19,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scrollbars="vertical"
-            app:visible="@{viewModel.uiState == UIState.SUCCESS}"
+            app:visible="@{uiState == UIState.SUCCESS}"
             app:layoutManager="android.support.v7.widget.LinearLayoutManager" />
 
         <ImageView
@@ -29,13 +29,13 @@
             android:background="@color/background_white"
             android:contentDescription="@string/cd_no_connection_image"
             android:src="@drawable/no_connection"
-            app:visible="@{viewModel.uiState == UIState.NETWORK_ERROR}" />
+            app:visible="@{uiState == UIState.NETWORK_ERROR}" />
 
         <ProgressBar
             android:layout_width="@dimen/progressbar_size"
             android:layout_height="@dimen/progressbar_size"
             android:layout_gravity="center"
-            app:visible="@{viewModel.uiState == UIState.LOADING}" />
+            app:visible="@{uiState == UIState.LOADING}" />
     </FrameLayout>
 
 </layout>

--- a/DatabindingWithNewsApi/app/src/main/res/layout/fragment_list.xml
+++ b/DatabindingWithNewsApi/app/src/main/res/layout/fragment_list.xml
@@ -5,9 +5,9 @@
     <data>
         <variable
             name="viewModel"
-            type="com.enpassio.databindingwithnewsapi.viewmodel.MainViewModel" />
+            type="com.enpassio.databindingwithnewsapi.ui.MainViewModel" />
 
-        <import type="com.enpassio.databindingwithnewsapi.utils.UIState" />
+        <import type="com.enpassio.databindingwithnewsapi.model.UIState" />
     </data>
 
     <FrameLayout

--- a/DatabindingWithNewsApi/app/src/main/res/layout/fragment_list.xml
+++ b/DatabindingWithNewsApi/app/src/main/res/layout/fragment_list.xml
@@ -23,7 +23,6 @@
             app:layoutManager="android.support.v7.widget.LinearLayoutManager" />
 
         <ImageView
-            android:id="@+id/no_network_image"
             android:layout_width="@dimen/no_network_image_size"
             android:layout_height="@dimen/no_network_image_size"
             android:layout_gravity="center"
@@ -33,7 +32,6 @@
             app:visible="@{viewModel.uiState == UIState.NETWORK_ERROR}" />
 
         <ProgressBar
-            android:id="@+id/pb_in_fragment_list"
             android:layout_width="@dimen/progressbar_size"
             android:layout_height="@dimen/progressbar_size"
             android:layout_gravity="center"

--- a/DatabindingWithNewsApi/build.gradle
+++ b/DatabindingWithNewsApi/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
I refactored connectivity check again: connectivity check is done in viewmodel as we talked before. But considering the situation that user might quit the app with back button and return hours later, I made some small changes. So now:
If user quits the app with back button and returns later:
-He can still see the old data (if system didn't kill the app of course)
-IF there is no internet, he can still see the data but he also sees a snack warning.
-If turns on the internet and click retry, new data is fetched and shown. 
-And UIState doesn't turn to NETWORK_ERROR state if there is data. It shows a snack, but it shows also the list, if there is some old data.

I also moved the openWebSite method to the fragment. I had put it in viewmodel, with the aim to demonstrate method references. But as far as I understand, it is not good practice to put something with a reference to a view inside viewmodel. So I moved it back to the fragment.